### PR TITLE
Harmony 1862 - Make compatible with pystac upgrade in service lib

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,15 @@
-FROM continuumio/miniconda3:4.9.2-alpine
+FROM continuumio/miniconda3:24.7.1-0
 
 WORKDIR "/home"
 
 # Install the app dependencies into the base conda environment so we
 # don't need to activate a conda environment when running.
 # Need git to install harmony-service library from github
-RUN apk update
-RUN apk add git
+# RUN apk update
+# RUN apk add git
 COPY environment.yml .
 RUN conda env update --file environment.yml -n base
+RUN conda install -c conda-forge libgdal-hdf5
 
 # This is below the preceding layer to prevent Docker from rebuilding the
 # previous layer (forcing a conda reload of dependencies) whenever the

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ WORKDIR "/home"
 # don't need to activate a conda environment when running.
 COPY environment.yml .
 RUN conda env update --file environment.yml -n base
-RUN conda install -c conda-forge libgdal-hdf5
 
 # This is below the preceding layer to prevent Docker from rebuilding the
 # previous layer (forcing a conda reload of dependencies) whenever the

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,6 @@ WORKDIR "/home"
 
 # Install the app dependencies into the base conda environment so we
 # don't need to activate a conda environment when running.
-# Need git to install harmony-service library from github
-# RUN apk update
-# RUN apk add git
 COPY environment.yml .
 RUN conda env update --file environment.yml -n base
 RUN conda install -c conda-forge libgdal-hdf5

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: install test lint test-watch build-image push-image
 
 install:
-	conda-env update --file environment-dev.yml
+	conda env update --file environment-dev.yml
 
 test:
 	pytest --ignore deps

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For building & pushing the image locally:
 
 For local development:
 
-1. miniconda3-4.7.12 (can be installed via pyenv)
+1. miniconda3-24.7.1 (can be installed via pyenv)
 
 ## Local Development
 
@@ -32,7 +32,7 @@ For local development:
 
 ### Developing with a local version of the Harmony Service Library
 
-You may want to test Harmony GDAL with an unreleased version of the Harmony Service Library.  This might be someone else's feature or bug-fix branch, or perhaps your own local changes. If you haven't already, clone the Harmony Service Lib and switch to an unreleased branch or make your local changes. Typically this clone would be in a sibling directory of Harmony GDAL:
+You may want to test Harmony Service Example with an unreleased version of the Harmony Service Library.  This might be someone else's feature or bug-fix branch, or perhaps your own local changes. If you haven't already, clone the Harmony Service Library and switch to an unreleased branch or make your local changes. Typically this clone would be in a sibling directory of Harmony Service Example:
 
         $ git clone https://github.com/nasa/harmony-service-lib-py ../harmony-service-lib-py
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ If you plan to build the Docker image and are running Docker in Docker, you'll a
 # Set to 'true' if running Docker in Docker and the docker daemon is somewhere other than the current context
 DIND=true
 
+# Set the PLATFORM varible to define the platform of the build output 
+PLATFORM=linux/amd64
+
 # Indicates where docker commands should find the docker daemon
 DOCKER_DAEMON_ADDR=host.docker.internal:2375
 ```

--- a/bin/build-image
+++ b/bin/build-image
@@ -24,5 +24,5 @@ fi
 if [ -n "$DIND" ]; then
   docker -H $DOCKER_DAEMON_ADDR build --build-arg service_lib_dir="$SERVICE_LIB_DIR" -t ${image}:${ag} .
 else
-  docker build --build-arg service_lib_dir="$SERVICE_LIB_DIR" --network host -t ${image}:${tag} .
+  docker build --platform linux/amd64 --build-arg service_lib_dir="$SERVICE_LIB_DIR" --network host -t ${image}:${tag} .
 fi

--- a/bin/build-image
+++ b/bin/build-image
@@ -20,9 +20,14 @@ if [ -d "$LOCAL_SVCLIB_DIR" ]; then
   cp -R $LOCAL_SVCLIB_DIR deps/
 fi
 
+PLATFORM_ARG=""
+if [ -n "$PLATFORM" ]; then
+  PLATFORM_ARG="--platform ${PLATFORM}"
+fi
+
 # If we're running Docker in Docker (DIND) then the docker daemon is on the host
 if [ -n "$DIND" ]; then
-  docker -H $DOCKER_DAEMON_ADDR build --build-arg service_lib_dir="$SERVICE_LIB_DIR" -t ${image}:${ag} .
+  docker -H $DOCKER_DAEMON_ADDR build ${PLATFORM_ARG} --build-arg service_lib_dir="$SERVICE_LIB_DIR" -t ${image}:${ag} .
 else
-  docker build --platform linux/amd64 --build-arg service_lib_dir="$SERVICE_LIB_DIR" --network host -t ${image}:${tag} .
+  docker build ${PLATFORM_ARG} --build-arg service_lib_dir="$SERVICE_LIB_DIR" --network host -t ${image}:${tag} .
 fi

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -5,7 +5,7 @@ dependencies:
   - ipython~=7.9
   - jedi~=0.17.0
   - pylint~=2.5
-  - pytest~=5.3
+  - pytest~=7.4.4
   - pip~=20.1
   - pip:
     - pytest-watch~=4.2

--- a/environment.yml
+++ b/environment.yml
@@ -5,5 +5,6 @@ dependencies:
   - gdal~=3.1
   - pip~=20.1
   - python=3.9
+  - libgdal-netcdf~=3.9.2
   - pip:
     - git+https://github.com/nasa/harmony-service-lib-py.git

--- a/environment.yml
+++ b/environment.yml
@@ -1,9 +1,9 @@
 channels:
   - conda-forge
 dependencies:
-  - boto3~=1.11
+  - boto3~=1.35.24
   - gdal~=3.1
   - pip~=20.1
-  - python=3.8.5
+  - python=3.9
   - pip:
     - git+https://github.com/nasa/harmony-service-lib-py.git


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1862

## Description
This makes service example compatible with the pystac upgrade in https://github.com/nasa/harmony-service-lib-py/pull/47. It should be merged before the service lib changes since this service always pulls in the latest service lib.

Upgraded:
python (3.9)
base conda image (latest)
pytest
boto

Also added a variable for PLATFORM that can be passed to the `make build-image` command. 

## Local Test Steps

Test a with local Harmony deployment:
1. Checkout branch HARMONY-1862 of this repo
2. `make build-image PLATFORM=linux/amd64`
3. Update your local Harmony instance service deployment to use the newly built image.
4. Run an example request and make sure it succeeds.

Standalone test:
1. If you don't have minconda installed: https://formulae.brew.sh/cask/miniconda
2. with your conda 24.7.1 environment activated:
3. `make install`
4. `make test` 

Also see https://github.com/nasa/harmony-service-lib-py/pull/47 "Test a service" for end-to-end testing instructions with the HARMONY-1862 branch of the service lib.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)