### PR TITLE
HARMONY-1781: Change harmony library references to harmony_service_lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,5 @@ deps
 
 # Snyk / Deepcode AI
 .dccache
+
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ WORKDIR "/home"
 COPY environment.yml .
 RUN conda env update --file environment.yml -n base
 
+ENV PROJ_LIB=/opt/conda/share/proj
+ENV GDAL_DATA=/opt/conda/share/gdal
+
 # This is below the preceding layer to prevent Docker from rebuilding the
 # previous layer (forcing a conda reload of dependencies) whenever the
 # status of a local service library changes

--- a/bin/harmony_service_example
+++ b/bin/harmony_service_example
@@ -8,7 +8,7 @@ args=""
 
 if [ -d ../harmony-service-lib-py ]; then
   (cd ../harmony-service-lib-py && make clean)
-  args="$args -v $(pwd)/../harmony-service-lib-py/harmony:/usr/lib/harmony-service-lib-py/harmony"
+  args="$args -v $(pwd)/../harmony-service-lib-py/harmony_service_lib:/usr/lib/harmony-service-lib-py/harmony_service_lib"
   args="$args -e PYTHONPATH=/usr/lib/harmony-service-lib-py"
 fi
 

--- a/harmony_service_example/__main__.py
+++ b/harmony_service_example/__main__.py
@@ -8,7 +8,7 @@ Runs the harmony_service_example CLI
 
 import argparse
 import logging
-import harmony
+import harmony_service_lib
 
 from .transform import HarmonyAdapter
 
@@ -23,10 +23,10 @@ def main():
     """
     parser = argparse.ArgumentParser(
         prog='harmony_service_example', description='Run the example service')
-    harmony.setup_cli(parser)
+    harmony_service_lib.setup_cli(parser)
     args = parser.parse_args()
-    if (harmony.is_harmony_cli(args)):
-        harmony.run_cli(parser, args, HarmonyAdapter)
+    if (harmony_service_lib.is_harmony_cli(args)):
+        harmony_service_lib.run_cli(parser, args, HarmonyAdapter)
     else:
         parser.error("Only --harmony CLIs are supported")
 

--- a/harmony_service_example/transform.py
+++ b/harmony_service_example/transform.py
@@ -12,8 +12,8 @@ import shutil
 from tempfile import mkdtemp
 
 from harmony_service_example.geo import clip_bbox
-from harmony import BaseHarmonyAdapter
-from harmony.util import generate_output_filename, download, HarmonyException, stage
+from harmony_service_lib import BaseHarmonyAdapter
+from harmony_service_lib.util import generate_output_filename, download, HarmonyException, stage
 from pystac import Asset
 
 from osgeo import gdal


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1781

## Description
Updates to handle the change in the library name from harmony to harmony_service_lib in the service library.

## Local Test Steps
1. Check out Danny's branch in the harmony-service-library which renames the library. You may have to first add his remote:
```
git remote add danny https://github.com/danielfromearth/harmony-service-lib-py.git
git fetch danny feature/issue-44-rename-package
```
2. Make sure you are configured to use a local copy of the service library and build the image.
```
make build-image PLATFORM=linux/amd64 LOCAL_SVCLIB_DIR=../harmony-service-lib-py
```
3. Run the tests:
```
make test
```
4. In the main harmony repo restart your harmony-service-example image with `bin/restart-services`.
5. Issue a request like http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/blue_var/coverage/rangeset?subset=lat(20%3A60)&subset=lon(-140%3A-50)&granuleId=G1233800343-EEDTEST&outputCrs=EPSG%3A31975&format=image%2Fpng and verify it completes successfully.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)