### PR TITLE
HARMONY-1962: Ensure gdal and libgdal libraries are set to the same versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM continuumio/miniconda3:24.7.1-0
+FROM continuumio/miniconda3:24.9.2-0
 
 WORKDIR "/home"
 

--- a/environment.yml
+++ b/environment.yml
@@ -2,10 +2,10 @@ channels:
   - conda-forge
 dependencies:
   - boto3~=1.35.24
-  - gdal=3.9.2
-  - libgdal=3.9.2
+  - gdal=3.10.0
+  - libgdal=3.10.0
   - pip~=20.1
   - python=3.9
-  - libgdal-netcdf=3.9.2
+  - libgdal-netcdf=3.10.0
   - pip:
     - git+https://github.com/nasa/harmony-service-lib-py.git

--- a/environment.yml
+++ b/environment.yml
@@ -2,9 +2,10 @@ channels:
   - conda-forge
 dependencies:
   - boto3~=1.35.24
-  - gdal~=3.1
+  - gdal=3.9.2
+  - libgdal=3.9.2
   - pip~=20.1
   - python=3.9
-  - libgdal-netcdf~=3.9.2
+  - libgdal-netcdf=3.9.2
   - pip:
     - git+https://github.com/nasa/harmony-service-lib-py.git


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1962

## Description
Fixes the issue we were seeing with gdal complaining about shared libraries when executing a request.

## Local Test Steps
* Run `bin/build-image` to build the image in this repo.
* Run `bin/restart-services` in the main harmony repo to restart the harmony-service-example pod
* Submit a request and verify it is successful. For example: http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/blue_var/coverage/rangeset?subset=lat(20%3A60)&subset=lon(-140%3A-50)&granuleId=G1233800343-EEDTEST&outputCrs=EPSG%3A31975&format=image%2Fpng&label=first&label=second


## PR Acceptance Checklist
* [X] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)