### PR TITLE
HARMONY-2077: Add CODEOWNERS file to make github auto-add reviewers to PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @indiejames @chris-durbin @ygliuvt


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2077

## Description
Add CODEOWNERS file to make github auto-add reviewers to PRs

## Local Test Steps
None

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)